### PR TITLE
Textual fixes

### DIFF
--- a/fcp-0000.md
+++ b/fcp-0000.md
@@ -36,7 +36,7 @@ FCPs also use the IETF interpretations of the keywords "MUST", "MUST NOT",
 "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
 and "OPTIONAL" as defined in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-The rest of this FCP documents when, why and how to write an FCP.
+The rest of this FCP documents when, why, and how to write an FCP.
 
 ## When should I write an FCP?
 
@@ -46,8 +46,8 @@ that make up the FreeBSD Community, to better understand how each change will
 impact those users.
 
 An FCP MUST be written when:
-* Any change that lacks consensus or is contended.
-* Creating, changing or removing a feature that is likely to cause user
+* Any change lacks consensus or is contended.
+* Creating, changing, or removing a feature that is likely to cause user
   confusion, i.e. a violation of the Principle of Least Astonishment or POLA.
 * Breaking changes to the behaviour of existing commands or libraries.
 * Substantive change to the behaviour or function of the ports or packaging
@@ -73,7 +73,7 @@ An FCP SHOULD address the following questions:
 The problem should be clearly described in sufficient detail such that someone
 unfamiliar with the issue can gain enough context to understand the proposed
 solution. The description of the problem SHOULD NOT be combined with the
-description of the solution. Ideally the problem is described first and
+description of the solution. Ideally, the problem is described first and
 discussed followed by a description of the intended solution(s) and discussion
 of those.
 
@@ -131,11 +131,11 @@ An FCP can be in one of the following states:
 1. rejected
 1. withdrawn
 
-As above an FCP is first created in the `draft` state. Before publicizing
+An FCP is first created in the `draft` state. Before publicizing
 the FCP to the mailing lists, the author is encouraged to contact
 fcp-editors@freebsd.org for editorial review. Once the draft is ready, it moves
 to the `feedback` state and is published to the fcp@freebsd.org mailing list
-and CCd to other appropriate forums, e.g. related technical lists.
+and CCed to other appropriate forums, e.g. related technical lists.
 
 The `feedback` state is where all discussion of the FCP takes place. Various
 contributors will provide feedback on the changes proposed in the FCP and their
@@ -163,7 +163,7 @@ To create a new FCP, an author MUST take the following steps.
 
 A [template](./template.md) is provided in the
 [FCP repository](https://github.com/freebsd/fcp). FCPs MUST have a text width
-of 80 columns. Extra material such as code samples, graphs and the like may
+of 80 columns. Extra material such as code samples, graphs, etc. may
 be provided and MUST be named starting with the FCP number like so:
 
   `fcp-0000-code-sample-1.c`
@@ -281,8 +281,7 @@ withdrawal.
 
 FCPs may need to be revised after they have been moved into the `accepted`
 state.  If the changes are minor then the author SHOULD update the FCP but if
-they the changes are major the FCP SHOULD be withdrawn the current FCP and
-restarted.
+the changes are major the FCP SHOULD be withdrawn and restarted.
 
 Examples of minor changes include spelling or wording fixes that do not change
 the meaning of the document.


### PR DESCRIPTION
This change contains:
- adding Oxford commas, 
- remove superfluous words,
- kill an obvious "as above" right below the list,
- add an 'e' to CCed (I think that is more common)
- replace an "and the like" with "etc."
- delete some text from last sentence in the "Changes after acceptance" section to make more sense.