### PR TITLE
Have a sub-directory per FCP

### DIFF
--- a/fcp-0000/fcp-0000.md
+++ b/fcp-0000/fcp-0000.md
@@ -18,7 +18,7 @@ changed: 2017-06-09T16:20+0000
 # FCP 0: FreeBSD Community Proposal Process and Authoring Guide
 
 Requests for Discussion are an idea originally promulgated by Joyent
-and based on the work with Requests for Comments, originating with the
+based on the work with Requests for Comments, originating with the
 IETF. The FreeBSD project has adopted a similar model of discussion and
 collaboration to facilitate major changes to the code or community of the
 project. Our model is based around documents we call FreeBSD Community
@@ -207,9 +207,17 @@ available number.
 
 ### Publish the FCP
 
+The FCP document and any additional material supplied for each FCP
+MUST be stored in a separate directory under the root of the FCP
+repository.  Directories should be named
+
+  `fcp-XXXX`
+
+where `XXXX` is the new FCP number.
+
 The FCP MUST be published under a filename of the form:
 
-  `fcp-XXXX.md`
+  `fcp-XXXX/fcp-XXXX.md`
 
 The XXXX MUST be replaced with the FCP number zero-padded to four digits. This
 zero-padding is not required for use when discussing the FCP in other venues

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 # This is the index of all FCPs
 
-FCP                       | State     | Owners                | Title
---------------------------|-----------|-----------------------|------
-[FCP 0](./fcp-0000.md)    | feedback  | allanjude, gnn, benno | FreeBSD Community Proposal Process and Authoring Guide
+FCP                             | State     | Owners                | Title
+--------------------------------|-----------|-----------------------|------
+[FCP 0](./fcp-0000/fcp-0000.md) | feedback  | allanjude, gnn, benno | FreeBSD Community Proposal Process and Authoring Guide


### PR DESCRIPTION
This was in the original Google doc, and I think it makes sense for
keeping the fcp repository reasonably tidy.