### PR TITLE
Edits for clarity and conciseness.

### DIFF
--- a/fcp-0000.md
+++ b/fcp-0000.md
@@ -29,7 +29,7 @@ Unlike RFCs from the IETF, our FCPs are maintained in
 format which provides more formal formatting structure and is also a format
 that is broadly used in the open source community.
 
-If you are unfamiliar with the IETF's Request for Comments (RFC) system please
+Those unfamiliar with the IETF's Request for Comments (RFC) system should
 read [RFC 3](https://tools.ietf.org/html/rfc3).
 
 FCPs also use the IETF interpretations of the keywords "MUST", "MUST NOT",
@@ -41,47 +41,48 @@ The rest of this FCP documents when, why, and how to write an FCP.
 ## When should I write an FCP?
 
 The purpose of the FCP process is to document the design decisions behind
-proposed changes and to gather feedback from the many different types of users
-that make up the FreeBSD Community, to better understand how each change will
-impact those users.
+proposed changes and gather feedback from the many different types of users
+that make up the FreeBSD community about how a change will impact those
+users.
 
-An FCP MUST be written when:
-* Any change lacks consensus or is contended.
-* Creating, changing, or removing a feature that is likely to cause user
-  confusion, i.e. a violation of the Principle of Least Astonishment or POLA.
-* Breaking changes to the behaviour of existing commands or libraries.
-* Substantive change to the behaviour or function of the ports or packaging
+An FCP SHOULD be written when:
+* A change lacks consensus or is significantly contended.
+* Creating, changing, or removing a feature is likely to cause user
+  confusion, a violation of the Principle of Least Astonishment (POLA).
+* A change breaks the behavior of existing commands or libraries.
+* A substantive change to the behavior or function of the ports or packaging
   system.
-* Major changes to how people interact with the FreeBSD Community.
+* A change significantly impacts how people interact with the FreeBSD
+  community.
 * A change that is proposed or committed which results in significant
   objections should use the FCP process to come to a resolution.
 
 Every FCP MUST have a title that is a simple synopsis of the document. Titles
-are not fixed; FCPs are numbered to allow the title to change. An FCP MUST
+are not fixed. FCPs are numbered to allow the title to change. An FCP MUST
 have the following attributes:
 
-* **Title**: This is a simple synopsis of the document. As stated the title is
+* **Title**: A simple synopsis of the document. As stated, the title is
   not fixed. It may change as the FCP evolves.
-* **Number**: This allows easy reference to the FCP and should be allocated as
+* **Number**: An easy numerical reference to the FCP, allocated as
   described below.
-* **Metadata**: This tracks the author(s) and state of the FCP.
+* **Metadata**: Information to track the authors and state of the FCP.
 
-An FCP SHOULD address the following questions:
+An FCP SHOULD address these questions:
 
 ##### What is the problem to be solved?
 
-The problem should be clearly described in sufficient detail such that someone
-unfamiliar with the issue can gain enough context to understand the proposed
-solution. The description of the problem SHOULD NOT be combined with the
-description of the solution. The problem SHOULD be described first and discussed
-followed by a description of the intended solution(s) and discussion of those.
+Clearly describe the problem with enough detail for someone
+unfamiliar with the issue to understand the proposed
+solution. Give a description and discussion of the problem first. Follow this
+with a separate description and discussion of the proposed solution. Keep the
+problem and solution descriptions and discussions separate for clarity.
 
 Examples of problems are:
 
 * The lack of a feature.
 * A needed improvement to an existing feature.
 * An ambiguity in the functionality of the system.
-* An issue in a community process.
+* An issue with a community process.
 
 ##### How will users interact with these new or changed features?
 
@@ -96,11 +97,11 @@ be taken into account.
 ##### Will this change any public or private interfaces?
 
 If a public interface such as a command line program or its arguments, a
-library, or a syscall, is to be changed then list it here along with a brief,
-one or two line description of the intended change.
+library, or a syscall is to be changed, list it here along with a brief
+description of the intended change.
 
 Changes to private interfaces, those consumed by other internal parts of
-FreeBSD MUST also be listed with a similarly brief description of the intended
+FreeBSD, MUST also be listed with a similarly brief description of the intended
 change.
 
 ##### What is the upgrade impact?
@@ -132,9 +133,9 @@ An FCP can be in one of the following states:
 
 An FCP is first created in the `draft` state. Before publicizing
 the FCP to the mailing lists, the author is encouraged to contact
-fcp-editors@freebsd.org for editorial review. Once the draft is ready, it moves
+fcp-editors@freebsd.org for editorial review. When the draft is ready, it moves
 to the `feedback` state and is published to the fcp@freebsd.org mailing list
-and CCed to other appropriate forums, e.g. related technical lists.
+and CCed to other appropriate forums like related technical lists.
 
 The `feedback` state is where all discussion of the FCP takes place. Various
 contributors will provide feedback on the changes proposed in the FCP and their
@@ -147,11 +148,11 @@ SHOULD be updated to the `vote` state.
 At this time the FreeBSD Core Team will vote on the subject of the FCP. The
 result of vote moves the FCP into the `accepted` or `rejected` state.
 
-Just because something is in the `accepted` state does not mean that it cannot
-be updated and corrected. See the "Touching up" section for more information.
+FCPs in the `accepted` state can be
+updated and corrected. See the "Touching up" section for more information.
 
-At any time the author(s) may decide to withdraw an FCP. If an FCP is not
-viable or if an FCP must be ignored, it can be moved into the `withdrawn`
+The authors may withdraw an FCP at any time. If an FCP is not
+viable or if an FCP is to be ignored, it can be moved into the `withdrawn`
 state.
 
 ## Mechanics of an FCP
@@ -162,8 +163,8 @@ To create a new FCP, an author MUST take the following steps.
 
 A [template](./template.md) is provided in the
 [FCP repository](https://github.com/freebsd/fcp). FCPs MUST have a text width
-of 80 columns. Extra material such as code samples, graphs, etc. may
-be provided and MUST be named starting with the FCP number like so:
+of 80 columns. Extra material such as code samples, graphs, and other materials may
+be provided and MUST be named starting with the FCP number like this:
 
   `fcp-0000-code-sample-1.c`
 
@@ -182,23 +183,23 @@ changed: 2017-06-09T15:17+0000
 ---
 ```
 
-Only the `authors`, and the `state` are tracked.  There MAY be any number of
+Only `authors` and `state` values are tracked.  There MAY be any number of
 `authors`. `Author` entries MUST contain both name and e-mail address for
 proper attribution. A `changed` entry SHOULD be present and indicate the date
 the FCP was last modified. If present this attribute MUST be in
 [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
-format and in the UTC time zone. A good way to generate an appropriate
-timestamp is the the following date command:
+format and in the UTC time zone. An appropriate
+timestamp can be generated with this command:
 
   `$ date -u +%Y-%m-%dT%H:%M%z`
 
 ### Allocate a new FCP number
 
-FCPs are numbered starting at 100. The first 100 FCPs, including this one, are
+Submitted FCPs are numbered starting at 100. FCPs with numbers lower than 100 are
 reserved for documenting the processes of the FreeBSD Project. When an FCP is
 started, the next currently unallocated number MUST be used.
 
-The author MUST go to the [FCP repository](https://github.com/freebsd/fcp) and
+An FCP author MUST go to the [FCP repository](https://github.com/freebsd/fcp) and
 allocate a new number in the `index.md` file. This can be done via the editor
 on the Github website itself or by creating a pull request manually. In the
 event of a number conflict the author MUST attempt to allocate the next
@@ -223,44 +224,44 @@ The FCP must be added to the repository in the `draft` state.
 
 ### Gather input on the FCP
 
-Once the FCP has been published the author should seek input from the
+After the FCP has been published, the author should seek input from the
 fcp-editors@freebsd.org list and any other contributors or forums that seem
 appropriate. If this feedback results in edits to the FCP these edits MUST
 be reflected in the FCP repository as soon as practical. The `changed` metadata
 attribute, if present, MUST be kept up to date.
 
-Once an FCP has reached a state where the author feels it is complete it
+When the author feels an FCP is complete, it
 can move on to the `feedback` state described below.
 
 ### Start the feedback process
 
-To start the feedback process both the FCP document itself and the FCP index
-document in the repository MUST be updated to indicate that the FCP is in the
+Feedback begins when the FCP document itself and the FCP index
+document in the repository are updated to indicate that the FCP is in the
 `feedback` state. The FCP MUST then be announced on the fcp@freebsd.org list
-and any other forums, e.g. topic-specific mailing lists, that are appropriate
+and any other forums, like topic-specific mailing lists, that are appropriate
 to the content of the FCP.
 
 The subject of the announcement MUST include the FCP number and title. The
 body of the announcement MUST include a link to the FCP along with a summary
 which can be any abstract or summary from the document itself.
 
-As the feedback process continues any edits to the FCP MUST be reflected in
+As the feedback process continues, any edits to the FCP MUST be reflected in
 the repository copy as soon as is practical. The `changed` metadata attribute,
 if present, MUST be kept up to date.
 
 ### Submit to core vote
 
-Once the feedback process has concluded the author MUST request a vote on the
-FCP by updating the FCP itself and the index to indicate that it is in the
+After the feedback process has concluded, the author MUST request a vote on the
+FCP by updating the FCP itself and the index to indicate it is in the
 `vote` state. The FCP author MUST also notify core@freebsd.org. The email
 to core MUST have the FCP number and title in the subject line and a summary
 of the FCP along with a link to the repository copy of the FCP in the body.
 The author SHOULD provide pointers to relevant discussion on the FCP in the
 various forums where it has been discussed.
 
-Once received by core, core MAY request more information if it is needed to
-inform their vote. Core MAY also notify the author that they need additional
-time to deliberate. If core has not specifically requested additional time,
+Core MAY request more information if it is needed to
+inform their vote. Core MAY also notify the author that additional
+time is needed to deliberate. If core has not specifically requested additional time,
 core MUST complete its deliberation and voting process within two weeks.
 
 The core vote will result in the FCP being moved to either the `accepted` or
@@ -270,7 +271,7 @@ their decision.
 
 ### Withdrawal
 
-At any point and for any reason prior to the resolution of the core vote the
+At any point prior to the resolution of the core vote, the
 author MAY withdraw their FCP. If an FCP is withdrawn it MUST be indicated in
 the FCP itself and the FCP index by changing the FCP state to `withdrawn`.
 The author MAY add a section to the FCP detailing the reasoning behind the
@@ -278,9 +279,9 @@ withdrawal.
 
 ### Changes after acceptance
 
-FCPs may need to be revised after they have been moved into the `accepted`
-state.  If the changes are minor then the author SHOULD update the FCP but if
-the changes are major the FCP SHOULD be withdrawn and restarted.
+FCPs may need revision after they have been moved into the `accepted`
+state.  If the changes are minor, the author SHOULD update the FCP. If
+the changes are major, the FCP SHOULD be withdrawn and restarted.
 
-Examples of minor changes include spelling or wording fixes that do not change
+Examples of minor changes include spelling corrections or wording changes that do not change
 the meaning of the document.


### PR DESCRIPTION
These edits improve the clarity of the document, but I am still concerned about the formality of the document.  This type of formality can be used by internet lawyers(TM) to defeat the intent of such documents.